### PR TITLE
🐛 fix(BDialog): zIndex should be updated when shown

### DIFF
--- a/src/Component/BlazorComponent/Components/Dialog/BDialog.razor.cs
+++ b/src/Component/BlazorComponent/Components/Dialog/BDialog.razor.cs
@@ -94,6 +94,8 @@ namespace BlazorComponent
 
             if (value)
             {
+                ZIndex = await GetActiveZIndex(value);
+
                 NextTick(async () =>
                 {
                     // TODO: previousActiveElement
@@ -121,8 +123,6 @@ namespace BlazorComponent
                     DotNetObjectReference.Create(new Invoker<object>(HandleOnOutsideClickAsync)),
                     new[] { Document.GetElementByReference(DialogRef).Selector },
                     new[] { Document.GetElementByReference(OverlayRef!.Value).Selector });
-
-                ZIndex = await GetActiveZIndex(value);
 
                 await JsInvokeAsync(JsInteropConstants.AddElementTo, OverlayRef, AttachSelector);
                 await JsInvokeAsync(JsInteropConstants.AddElementTo, ContentRef, AttachSelector);


### PR DESCRIPTION
resolve [#440.](https://github.com/BlazorComponent/MASA.Blazor/issues/440)