### PR TITLE
🐛 fix: set clearDelay public to accommodate earlier versions of browsers

### DIFF
--- a/src/Component/BlazorComponent/wwwroot/js/delayable.js
+++ b/src/Component/BlazorComponent/wwwroot/js/delayable.js
@@ -12,13 +12,13 @@ class Delayable {
         this.#closeDelay = closeDelay;
     }
 
-    #clearDelay() {
+    clearDelay() {
         clearTimeout(this.#openTimeout);
         clearTimeout(this.#closeTimeout);
     }
 
     runDelay(type, cb) {
-        this.#clearDelay();
+        this.clearDelay();
 
         if (type === "open") {
             const delay = parseInt(this.#openDelay, 10);


### PR DESCRIPTION
resolve https://github.com/BlazorComponent/MASA.Blazor/issues/454