### PR TITLE
fix: ValidationMessageStore null exception throws when EnableValidation is false

### DIFF
--- a/src/Component/BlazorComponent/Components/Form/BForm.razor.cs
+++ b/src/Component/BlazorComponent/Components/Form/BForm.razor.cs
@@ -63,9 +63,11 @@ namespace BlazorComponent
             {
                 EditContext = new EditContext(Model);
 
+                // 未开启EnableValidation也需要初始化ValidationMessageStore，否则
+                // 用户手动调用ParseFormValidation，设置错误信息时，报空引用异常
+                ValidationMessageStore = new ValidationMessageStore(EditContext);
                 if (EnableValidation)
                 {
-                    ValidationMessageStore = new ValidationMessageStore(EditContext);
                     _editContextValidation = EditContext.EnableValidation(ValidationMessageStore, ServiceProvider, EnableI18n);
                 }
 

--- a/src/Component/BlazorComponent/Components/Form/BForm.razor.cs
+++ b/src/Component/BlazorComponent/Components/Form/BForm.razor.cs
@@ -63,8 +63,6 @@ namespace BlazorComponent
             {
                 EditContext = new EditContext(Model);
 
-                // 未开启EnableValidation也需要初始化ValidationMessageStore，否则
-                // 用户手动调用ParseFormValidation，设置错误信息时，报空引用异常
                 ValidationMessageStore = new ValidationMessageStore(EditContext);
                 if (EnableValidation)
                 {
@@ -212,7 +210,6 @@ namespace BlazorComponent
                 var validatable = Validatables.FirstOrDefault(item => item.ValueIdentifier.Equals(fieldIdentifier));
                 if (validatable is not null)
                 {
-                    validatable.Validate();
                     ValidationMessageStore.Clear(fieldIdentifier);
                     ValidationMessageStore.Add(fieldIdentifier, validationResult.Message);
                 }


### PR DESCRIPTION
Form验证目前不支持异步验证。我目前的解决方案是在外部执行异步参数验证，然后调用form.ParseFormValidation设置错误提示，但是在未开启EnableValidation情况下，ValidationMessageStore为null，此时设置错误信息会报空引用异常