### PR TITLE
🐛 fix(Switch): click does not work when ripple is false

### DIFF
--- a/src/Component/BlazorComponent/Components/Switch/Switch/Input/BSelectableInput.razor
+++ b/src/Component/BlazorComponent/Components/Switch/Switch/Input/BSelectableInput.razor
@@ -10,7 +10,6 @@
        value="@InternalValue"
        checked="@IsActive"
        @onclick:preventDefault
-       @onclick:stopPropagation
        @onblur="@HandleOnBlur"
        @onchange="@HandleOnChange"
        @onfocus="@HandleOnFocus"


### PR DESCRIPTION
resolve BlazorComponent/Masa.Blazor#957