### PR TITLE
fix(Select): expose the `MaxWidth` parameters of Menu

### DIFF
--- a/src/Component/BlazorComponent/Components/Menu/BMenuProps.cs
+++ b/src/Component/BlazorComponent/Components/Menu/BMenuProps.cs
@@ -16,6 +16,7 @@
 
         public StringNumber? MaxHeight { get; set; }
 
+        public StringNumber? MaxWidth { get; set; }
         public StringNumber? MinWidth { get; set; }
 
         public StringNumber? NudgeBottom { get; set; }


### PR DESCRIPTION
MSelect component's MenuProps property unexposed 'MaxWidth' property #1030
![image](https://user-images.githubusercontent.com/38368335/220570893-5e17a235-2e9d-4ff2-bed6-1cc2fd49d750.png)
