### PR TITLE
fix(Select):Expose the ```MaxWidth``` parameters of Menu

### DIFF
--- a/src/Component/BlazorComponent/Components/Menu/BMenuProps.cs
+++ b/src/Component/BlazorComponent/Components/Menu/BMenuProps.cs
@@ -16,6 +16,8 @@
 
         public StringNumber? MaxHeight { get; set; }
 
+        public StringNumber? MaxWidth { get; set; }
+
         public StringNumber? MinWidth { get; set; }
 
         public StringNumber? NudgeBottom { get; set; }


### PR DESCRIPTION
fix:MASA.Blazor MSelect component's MenuProps property unexposed 'MaxWidth' property #1030