### PR TITLE
🐛 fix(Icon): missing type='button' in form

### DIFF
--- a/src/Component/BlazorComponent/Components/Icon/BIcon.razor
+++ b/src/Component/BlazorComponent/Components/Icon/BIcon.razor
@@ -9,6 +9,7 @@
         Class="@CssProvider.GetClass()"
         Style="@CssProvider.GetStyle()"
         ReferenceCaptureAction="_ => Ref = _"
+        type="@(OnClick.HasDelegate ? "button" : null)"
         @attributes="@Attributes">
         @if (IconType == IconType.Svg)
         {


### PR DESCRIPTION
link to masastack/MASA.Auth#736