### PR TITLE
fix(ExpansionPanels): InternalValues should not be reset if value is not assigned

### DIFF
--- a/src/Component/BlazorComponent/Components/ItemGroup/ItemGroupBase.cs
+++ b/src/Component/BlazorComponent/Components/ItemGroup/ItemGroupBase.cs
@@ -172,10 +172,14 @@ namespace BlazorComponent
         {
             if (Multiple)
             {
+                if (!IsDirtyParameter(nameof(Values))) return;
+
                 InternalValues = Values == null ? new List<StringNumber>() : Values.ToList();
             }
             else
             {
+                if (!IsDirtyParameter(nameof(Value))) return;
+
                 InternalValues = Value == null ? new List<StringNumber>() : new List<StringNumber>() { Value };
             }
         }


### PR DESCRIPTION
issues:
- masastack/MASA.DCC#436
- masastack/MASA.DCC#427